### PR TITLE
Scrolling doesn't work when content is added after the fact.

### DIFF
--- a/slimScroll.js
+++ b/slimScroll.js
@@ -189,6 +189,10 @@
 						* me.outerHeight(), minBarHeight);
 					bar.css({ height: height + 'px' });
 					clearTimeout(queueHide);
+					
+					if(height >= me.outerHeight()) {
+						return;
+					}
 					bar.fadeIn('fast');
 				}
 


### PR DESCRIPTION
If you enabled an element for slimScroll then added content to that element scrolling would not work as the scrolling is determined from the height of the scrollbar which was set when initially setting up the pane. This fixes the problem by updating the scrollbar height each time it is shown.
