### PR TITLE
Option of scrollbar out of content

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -99,7 +99,17 @@
 		  <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed diam sem, imperdiet at mollis vestibulum, bibendum id purus. Aliquam molestie, leo sed molestie condimentum, massa enim lobortis massa, in vulputate diam lorem quis justo. Nullam nec dignissim mi. In non varius nibh. Proin et eros nisi, eu vulputate libero. Suspendisse potenti. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Duis ultricies augue id risus dapibus blandit.</p>
 		  <p>Integer malesuada molestie dolor sit amet viverra. Mauris nec urna lorem. Integer commodo feugiat ligula eget fermentum. In in tellus a risus convallis pellentesque. Cras non faucibus est. Morbi sagittis risus mollis nisl mollis ac mattis mi volutpat. Vivamus ac rutrum elit. Suspendisse semper orci vitae sapien sollicitudin mattis.</p>
 	  </div>
-	  
+
+	   <hr /><h2>scrollbar in a holder out of block with content</h2>
+	  <div id="testbarholder">
+		  <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed diam sem, imperdiet at mollis vestibulum, bibendum id purus. Aliquam molestie, leo sed molestie condimentum, massa enim lobortis massa, in vulputate diam lorem quis justo. Nullam nec dignissim mi. In non varius nibh. Proin et eros nisi, eu vulputate libero. Suspendisse potenti. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Duis ultricies augue id risus dapibus blandit.</p>
+		  <p>Integer malesuada molestie dolor sit amet viverra. Mauris nec urna lorem. Integer commodo feugiat ligula eget fermentum. In in tellus a risus convallis pellentesque. Cras non faucibus est. Morbi sagittis risus mollis nisl mollis ac mattis mi volutpat. Vivamus ac rutrum elit. Suspendisse semper orci vitae sapien sollicitudin mattis.</p>
+		  <p>Integer malesuada molestie dolor sit amet viverra. Mauris nec urna lorem. Integer commodo feugiat ligula eget fermentum. In in tellus a risus convallis pellentesque. Cras non faucibus est. Morbi sagittis risus mollis nisl mollis ac mattis mi volutpat. Vivamus ac rutrum elit. Suspendisse semper orci vitae sapien sollicitudin mattis.</p>
+	  </div>
+
+  <div class="barholder" style="position: absolute; top: 1525px; left: 350px;">
+  </div>
+ 
 	<hr /><h2>float:left test, .slimscroll(), distance: 20px</h2>
 	  <div id="test3" style="float:left">
 		  <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed diam sem, imperdiet at mollis vestibulum, bibendum id purus. Aliquam molestie, leo sed molestie condimentum, massa enim lobortis massa, in vulputate diam lorem quis justo. Nullam nec dignissim mi. In non varius nibh. Proin et eros nisi, eu vulputate libero. Suspendisse potenti. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Duis ultricies augue id risus dapibus blandit.</p>
@@ -160,6 +170,14 @@
 				  position: 'left',
 				  width: '300px',
 				  height: '250px'
+			  });
+			  $('#testbarholder').slimScroll({
+				  position: 'left',
+				  width: '300px',
+				  height: '250px',
+				  barHolder: $('.barholder'),
+				  railVisible: true,
+				  alwaysVisible: true
 			  });
 			  //invalid name call
 			  $('#test3').slimscroll({

--- a/slimScroll.js
+++ b/slimScroll.js
@@ -26,7 +26,8 @@
         railOpacity : '0.2',
         railClass : 'slimScrollRail',
         barClass : 'slimScrollBar',
-        wrapperClass : 'slimScrollDiv'
+        wrapperClass : 'slimScrollDiv',
+        barHolder: null
       };
 
       var o = ops = $.extend( defaults , options );
@@ -50,7 +51,8 @@
         alwaysVisible = o.alwaysVisible,
         railVisible = o.railVisible,
         railColor = o.railColor,
-        railOpacity = o.railOpacity;
+        railOpacity = o.railOpacity,
+        barHolder = o.barHolder;
       
         // used in event handlers and for better minification
         var me = $(this);
@@ -112,9 +114,22 @@
         // wrap it
         me.wrap(wrapper);
 
-        // append to parent div
-        me.parent().append(bar);
-        me.parent().append(rail);
+        // append to bar holder or parent div
+        if (barHolder) {
+          var internalHolder = $(divS)
+            .css({
+              position: 'relative', 
+              height: me.parent().height()
+            })
+            .append(bar)
+            .append(rail);
+          $(barHolder)
+            .css({ width: size })
+            .append(internalHolder);
+        } else {
+          me.parent().append(bar);
+          me.parent().append(rail);
+        }
 
         // make it draggable
         bar.draggable({ 


### PR DESCRIPTION
I added the option 'barHolder' to put the scrollbar out of the div with the content that is scrolled. You can pass a div positioned anywhere (even absolutely positioned ones) and the scrollbar will be placed there. It will have the same height as the container with the content being scrolled.

Added an example as well (even though it might break if someone adds an example before).

Didn't minify, please let me know which tool you use and I'll do it.
