### PR TITLE
Support for automatically setting the height of the scroll area to the height of the parent element(s)

### DIFF
--- a/slimScroll.js
+++ b/slimScroll.js
@@ -30,12 +30,15 @@
         allowPageScroll: false,
         scroll: 0
       };
-
+      
       var o = ops = $.extend( defaults , options );
-
+      
+      // used in event handlers and for better minification
+      var me = $(this);
+      
       // do it for every element that matches selector
       this.each(function(){
-
+      
       var isOverPanel, isOverBar, isDragg, queueHide, barHeight, percentScroll,
         divS = '<div></div>',
         minBarHeight = 30,
@@ -55,10 +58,12 @@
         railOpacity = o.railOpacity,
         allowPageScroll = o.allowPageScroll,
         scroll = o.scroll;
-      
-        // used in event handlers and for better minification
-        var me = $(this);
-
+        
+        // optionally set height to the parent's height
+        if (cheight == 'auto') {
+          cheight = me.parent().innerHeight();
+        }
+        
         //ensure we are not binding it again
         if (me.parent().hasClass('slimScrollDiv'))
         {


### PR DESCRIPTION
In some cases, elements should auto-expand vertically to fill their parent element. In this case, it is easier if the scroller knows how to auto-size itself vertically, instead of having to manually calculate the height.

This change adds support for auto-expanding the scroller to fill the parent vertically when the height attribute is set to 'auto'.
