### PR TITLE
Trigger an event when scrolling. Bonus included.

### DIFF
--- a/jquery.slimscroll.js
+++ b/jquery.slimscroll.js
@@ -236,6 +236,8 @@
         {
           var delta = y;
           var maxTop = me.outerHeight() - bar.outerHeight();
+          
+          me.trigger('slimscrolling');
 
           if (isWheel)
           {


### PR DESCRIPTION
This is so useful when you want to recalculate the position of elements when something is scrolling (like tooltips).

Bonus: a rainbow :rainbow:
