### PR TITLE
Refresh slimscroll height for content changes

### DIFF
--- a/jquery.slimscroll.js
+++ b/jquery.slimscroll.js
@@ -102,6 +102,15 @@
             // check if we should scroll existing instance
             if ($.isPlainObject(options))
             {
+              // Pass height: auto to an existing slimscroll object to force a resize after contents have changed
+              if ( 'height' in options && options.height == 'auto' ) {
+                me.parent().css('height', 'auto');
+                me.css('height', 'auto');
+                var height = me.parent().parent().innerHeight();
+                me.parent().css('height', height);
+                me.css('height', height);
+              }
+
               if ('scrollTo' in options)
               {
                 // jump to a static point


### PR DESCRIPTION
Added the processing of `{ height: 'auto' }` for re-initializing the height of an existing instance. The div heights are recalculated based on the original wrapping div. This ensures a proper resize when using max-height to set the height of the original wrapping div. 
