### PR TITLE
allowPageScroll bug fixed

### DIFF
--- a/jquery.slimscroll.js
+++ b/jquery.slimscroll.js
@@ -388,6 +388,10 @@
                 me.trigger('slimscroll', msg);
             }
           }
+          else
+          {
+            releaseScroll = false;
+          }
           lastScroll = percentScroll;
 
           // show only when required


### PR DESCRIPTION
Fixed the bug:
When user sets "allowPageScroll" to true, the parent should only scroll when the scroll in on the boundary. But when the scroll touched one of the boundaries, the parent started to scroll even when the scroll in not at boundaries

Solution:
The variable "releaseScroll", one set to true, was never set to false. So I set it to false if the scroll is not at the end of the page.

Please verify that doing this will not cause any harm. If so, then please find another way to fix this bug. Also please change the minified version too.

Regards,
Muhammad Adeel
