### PR TITLE
Take in account the padding of containing element when height = auto

### DIFF
--- a/jquery.slimscroll.js
+++ b/jquery.slimscroll.js
@@ -20,6 +20,9 @@
 
         // width in pixels of the scrollbar and rail
         size : '7px',
+        
+        // oversize width in pixels of the scrollbar and rail
+        overSize : '14px',
 
         // scrollbar color, accepts any hex/color value
         color: '#000',
@@ -78,7 +81,7 @@
       // do it for every element that matches selector
       this.each(function(){
 
-      var isOverPanel, isOverBar, isDragg, queueHide, touchDif,
+      var isOverPanel, isOverBar, isOverRail, isDragg, queueHide, touchDif,
         barHeight, percentScroll, lastScroll,
         divS = '<div></div>',
         minBarHeight = 30,
@@ -219,16 +222,24 @@
 
         // on rail over
         rail.hover(function(){
+          isOverRail = true;
           showBar();
+          overSizeBar();
+          console.log("over");
         }, function(){
+          isOverRail = true;
           hideBar();
+          normalSizeBar();
+          console.log("outover");
         });
 
         // on bar over
         bar.hover(function(){
           isOverBar = true;
+          overSizeBar();
         }, function(){
           isOverBar = false;
+          normalSizeBar();
         });
 
         // show on parent mouseover
@@ -374,10 +385,34 @@
           bar.css({ height: barHeight + 'px' });
 
           // hide scrollbar if content is not long enough
-          var display = barHeight == me.outerHeight() ? 'none' : 'block';
+          var display = me.outerHeight() - barHeight <= 1 ? 'none' : 'block';
           bar.css({ display: display });
+          if (o.railVisible) { rail.css({ display: display }); }
         }
 
+        function overSizeBar(){
+        	if (isOverBar || isOverRail){
+        		bar.css('width', o.overSize);
+                rail.css('width', o.overSize);
+        	}
+        }
+        
+        function normalSizeBar(check){
+        	if(typeof check === "undefined"){
+        		check = true;
+        	}
+        	if (check){
+        		if (!isOverBar && !isOverRail && !isDragg){
+            		bar.css('width', o.size);
+                    rail.css('width', o.size);
+            	}
+        	}else{
+        		bar.css('width', o.size);
+                rail.css('width', o.size);
+        	}
+        	
+        }
+        
         function showBar()
         {
           // recalculate bar height
@@ -400,7 +435,7 @@
           lastScroll = percentScroll;
 
           // show only when required
-          if(barHeight >= me.outerHeight()) {
+          if(barHeight >= me.outerHeight() - 1) {
             //allow window scroll
             releaseScroll = true;
             return;
@@ -419,9 +454,11 @@
               {
                 bar.fadeOut('slow');
                 rail.fadeOut('slow');
+                normalSizeBar(false);
               }
             }, 1000);
           }
+          
         }
 
       });


### PR DESCRIPTION
Uses parent.parent.height, instead of parent.parent.innerHeight to take
in acount the padding of the containing element whent the height is set
to 'auto'
