### PR TITLE
Fixed problem where bar position was set before bar height was calculated.

### DIFF
--- a/jquery.slimscroll.js
+++ b/jquery.slimscroll.js
@@ -262,6 +262,9 @@
           }
         });
 
+        // set up initial height
+        getBarHeight();
+
         // check start position
         if (o.start === 'bottom')
         {
@@ -280,9 +283,6 @@
 
         // attach scroll events
         attachWheel();
-
-        // set up initial height
-        getBarHeight();
 
         function _onWheel(e)
         {


### PR DESCRIPTION
Bar position was set before bar height was calculated. This caused bar to be positioned outside the screen, and there was to way to get it back.

Fix is trivial.
