### PR TITLE
[Critical Bug] dynamically assign isOverPanel to reduce mistaken mousewheel captures

### DIFF
--- a/jquery.slimscroll.js
+++ b/jquery.slimscroll.js
@@ -93,6 +93,11 @@
         // used in event handlers and for better minification
         var me = $(this);
 
+        // create a simple function to check if panel is being hovered over.
+        isOverPanel = function () {
+          return me.is(":hover");
+        }
+
         // ensure we are not binding it again
         if (me.parent().hasClass(o.wrapperClass))
         {
@@ -249,11 +254,9 @@
 
         // show on parent mouseover
         me.hover(function(){
-          isOverPanel = true;
           showBar();
           hideBar();
         }, function(){
-          isOverPanel = false;
           hideBar();
         });
 
@@ -307,7 +310,7 @@
         function _onWheel(e)
         {
           // use mouse wheel only when mouse is over
-          if (!isOverPanel) { return; }
+          if (!isOverPanel()) { return; }
 
           var e = e || window.event;
 
@@ -440,7 +443,7 @@
           if (!o.alwaysVisible)
           {
             queueHide = setTimeout(function(){
-              if (!(o.disableFadeOut && isOverPanel) && !isOverBar && !isDragg)
+              if (!(o.disableFadeOut && isOverPanel()) && !isOverBar && !isDragg)
               {
                 bar.fadeOut('slow');
                 rail.fadeOut('slow');


### PR DESCRIPTION
I found that slimScroll was causing my mousewheel behaviour to break (become completely inoperable) occasionally.

Steps to replicate:
1. initialize a slimScroll element
2. hover over the element
3. destroy slimScroll while still hovering over the element
4. Try to scroll in the browser window

Expect:
1. Scroll works normally

Get:
1. Scroll does not work at all, in any browser.

The cause: 
1. if slimScroll gets destroyed while the mouse is hovered over the scroll (e.g. if the slimScroll content has a link, in a pushState site), 
2. isOverPanel is still assigned as true at the point of destroying slimScroll
3. then, _onWheel will execute instead of a normal browser scroll..

This pull request suggests changing isOverPanel to a simple function that gets assessed at the time it is needed, to avoid false assignments.
