### PR TITLE
Allowing use of max-height on the content div

### DIFF
--- a/jquery.slimscroll.js
+++ b/jquery.slimscroll.js
@@ -168,7 +168,7 @@
           .addClass(o.railClass)
           .css({
             width: o.size,
-            height: '100%',
+            height: o.height ? '100%' : '',
             position: 'absolute',
             top: 0,
             display: (o.alwaysVisible && o.railVisible) ? 'block' : 'none',


### PR DESCRIPTION
Issue #70 describes that people would like to be able to use max-height on the content div.

This is actually currently do-able by configuring as follows:

$(function(){
    $('#your-content-div-with-max-height').slimScroll({
        height: ''
    });
});

But the scroll rail files off the handle.
