### PR TITLE
Allow multilevel slimscrolls

### DIFF
--- a/jquery.slimscroll.js
+++ b/jquery.slimscroll.js
@@ -100,8 +100,8 @@
             var offset = me.scrollTop();
 
             // find bar and rail
-            bar = me.parent().find('.' + o.barClass);
-            rail = me.parent().find('.' + o.railClass);
+            bar = me.closest('.' + o.barClass);
+            rail = me.closest('.' + o.railClass);
 
             getBarHeight();
 


### PR DESCRIPTION
Fixes issue #182: multilevel slimscrolls.

Changed the selector to select the right `bar` and `rail` element to remove from DOM.

In the issue https://github.com/rochal/jQuery-slimScroll/issues/182 is described that multilevel slimscrolls aren't allowed. On destroy of the parent slimscroll, the `bar`s and `rail`s DOM elements for the children scroll are removed.