### PR TITLE
Update jquery.slimscroll.js

### DIFF
--- a/jquery.slimscroll.js
+++ b/jquery.slimscroll.js
@@ -309,7 +309,7 @@
         }
 
         // attach scroll events
-        attachWheel();
+        attachWheel(this);
 
         function _onWheel(e)
         {
@@ -382,12 +382,12 @@
           hideBar();
         }
 
-        function attachWheel()
+        function attachWheel(target)
         {
           if (window.addEventListener)
           {
-            this.addEventListener('DOMMouseScroll', _onWheel, false );
-            this.addEventListener('mousewheel', _onWheel, false );
+            target.addEventListener('DOMMouseScroll', _onWheel, false );
+            target.addEventListener('mousewheel', _onWheel, false );
           }
           else
           {


### PR DESCRIPTION
Inside the attachWheel function, 'this' keyword is the Window object, not the DOM container, this could cause the page scroll blocked, because the _onWheel still being used to process the page scroll event while the slimscroll container has been destroyed.