### PR TITLE
fix issue of find bar and rail

### DIFF
--- a/jquery.slimscroll.js
+++ b/jquery.slimscroll.js
@@ -100,8 +100,8 @@
             var offset = me.scrollTop();
 
             // find bar and rail
-            bar = me.closest('.' + o.barClass);
-            rail = me.closest('.' + o.railClass);
+	    bar = me.parent().find('.' + o.barClass);
+	    rail = me.parent().find('.' + o.railClass);
 
             getBarHeight();
 


### PR DESCRIPTION
me.closest('.' + o.barClass) and me.closest('.' + o.barClass) can not find the correct element, it should use me.parent().find('.' + o.barClass) and me.parent().find('.' + o.railClass), or it could course double scroll bar in the scroll element.