### PR TITLE
fix allowPageScroll does not scroll to the bottom

### DIFF
--- a/jquery.slimscroll.js
+++ b/jquery.slimscroll.js
@@ -417,7 +417,7 @@
           clearTimeout(queueHide);
 
           // when bar reached top or bottom
-          if (percentScroll == ~~percentScroll)
+          if ((percentScroll > 1 ? 1 : percentScroll) == ~~percentScroll)
           {
             //release wheel
             releaseScroll = o.allowPageScroll;


### PR DESCRIPTION
The allowPageScroll option did not work correctly because percentScroll could exceed the value of 1 and would never be equal to ~~ percentScroll, limiting the value to 1 when validating the problem is corrected.